### PR TITLE
Infix to Postfix Conversion in C++

### DIFF
--- a/CPP/Stacks_Queues/infixToPostfix.cpp
+++ b/CPP/Stacks_Queues/infixToPostfix.cpp
@@ -1,0 +1,55 @@
+//infix to postfix conversion
+#include<iostream>
+#include<string>
+#include<stack>
+using namespace std;
+
+int priority(char op) {
+  if (op == '^') return 3;
+  if (op == '*' || op == '/') return 2;
+  if (op == '+' || op == '-') return 1;
+  return 0;
+}
+
+string infixToPostfix(string s){
+  int n = s.size();
+  int i=0;
+  stack<char> st;
+  string ans = "";
+  while(i<n){
+    if((s[i]>='A' && s[i]<='Z') || (s[i]>='a' && s[i]<='z') || (s[i]>='0' && s[i]<='9')){
+      ans = ans + s[i];
+    }
+    else if(s[i] == '('){
+      st.push(s[i]);
+    }
+    else if(s[i] == ')'){
+      while(!st.empty() && st.top() != '('){
+        ans += st.top();
+        st.pop();
+      }
+      st.pop(); // to pop opening bracket
+    }
+    else{//left only with operator
+      while(!st.empty() && (priority(s[i]) < priority(st.top()) || (priority(s[i]) == priority(st.top()) && s[i]!= '^'))){
+        ans += st.top();
+        st.pop();
+      }
+      st.push(s[i]);
+    }
+    i++;
+  }
+  while(!st.empty()){
+    ans += st.top();
+    st.pop();
+  }
+  return ans;
+}
+
+int main(){
+  string s = "A+B*(C^D-E)^F+G*H-I";
+  string ans = infixToPostfix(s);
+  cout<<ans;
+
+  return 0;
+}


### PR DESCRIPTION
### **Description**

This PR implements a **stack-based C++ program** to convert infix expressions (e.g., `A+B*(C^D-E)^F+G*H-I`) into **postfix notation**.

✅ **Features:**

* Handles **operator precedence** (`^`, `*`, `/`, `+`, `-`)
* Supports **right/left associativity**
* Handles **parentheses**, including nested ones
* Works with **letters and digits** as operands

💡 **Why it’s useful:**

* Helps beginners learn **stack operations** and **expression conversion**
* Useful for **compilers, calculators, or expression evaluators**
* Fully tested and compilation-safe

🧪 **Example:**

```
Input:  A+B*(C^D-E)^F+G*H-I
Output: ABCD^E-F^*+GH*+I-
```

---