### PR TITLE
 Infix to Prefix Conversion in C++

### DIFF
--- a/CPP/Stacks_Queues/infixToPrefix.cpp
+++ b/CPP/Stacks_Queues/infixToPrefix.cpp
@@ -1,0 +1,77 @@
+//infix to prefix
+#include<iostream>
+#include<stack>
+#include<string>
+#include<algorithm>
+using namespace std;
+
+int priority(char op) {
+  if (op == '^') return 3;
+  if (op == '*' || op == '/') return 2;
+  if (op == '+' || op == '-') return 1;
+  return 0;
+}
+
+string infixToPrefix(string &s){
+  reverse(s.begin(), s.end()); //reversed a string
+  int i=0;
+  int n = s.size();
+  while(i<n){//changing paranthesis
+    if(s[i]=='('){
+      s[i] = ')';
+    } 
+    else if(s[i]==')'){
+      s[i] = '(';
+    }
+    i++;
+  }
+
+  i=0;
+  string ans = "";
+  stack<char> st;
+  while(i<n){
+    if((s[i]>='a' && s[i]<='z') || (s[i]>='A' && s[i]<='Z') || (s[i]>='0' && s[i]<='9')){
+      ans = ans + s[i];
+    }
+    else if(s[i] == '('){
+      st.push(s[i]);
+    }
+    else if(s[i] == ')'){
+      while(!st.empty() && st.top() != '('){
+        ans += st.top();
+        st.pop();
+      }
+      st.pop();
+    }
+    else{
+      if(s[i] == '^'){
+        while(!st.empty() && priority(s[i]) <= priority(st.top())){
+          ans += st.top();
+          st.pop();
+        }
+      }
+      else{
+        while(!st.empty() && priority(s[i]) < priority(st.top())){
+          ans += st.top();
+          st.pop();
+        }
+      }
+      st.push(s[i]);
+    }
+    i++;
+  }
+  while(!st.empty()){
+    ans += st.top();
+    st.pop();
+  }
+  reverse(ans.begin(), ans.end());
+  return ans;
+}
+
+int main() {
+  string s = "A+B*(C^D-E)^F+G*H-I";
+  string ans = infixToPrefix(s);
+  cout<<ans<<endl;
+  return 0;
+}
+


### PR DESCRIPTION
This PR adds a **stack-based C++ program** to convert infix expressions into **prefix notation**.

✅ **Features:**

* Handles **operator precedence**: `^`, `*`, `/`, `+`, `-`
* Supports **right/left associativity** (`^` is right-associative)
* Works with **parentheses**, including nested expressions
* Supports **letters and digits** as operands

💡 **Why it’s useful:**

* Helps beginners understand **stacks, operator precedence, and expression conversions**
* Useful in **compilers, calculators, or expression evaluators**
* Fully tested and compilation-safe

🧪 **Example:**

```
Input:  A+B*(C^D-E)^F+G*H-I
Output: -+A*B^-^CDEF*GHI
```

